### PR TITLE
fix: dependabot eslint

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,3 +14,6 @@ updates:
     open-pull-requests-limit: 10
     assignees:
       - kazkansouh
+    groups:
+      typescript-eslint:
+        patterns: ["@typescript-eslint/*"]


### PR DESCRIPTION
Group all @typescript-eslint/* packages into a single PR, this is to fix peerDependency issues that causes CI tests to fail.